### PR TITLE
Extract price properties and index as double

### DIFF
--- a/src/Umbraco.Commerce.DemoStore/DemoStoreBuilderExtensions.cs
+++ b/src/Umbraco.Commerce.DemoStore/DemoStoreBuilderExtensions.cs
@@ -6,6 +6,8 @@ using Umbraco.Commerce.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Commerce.DemoStore.Web.Index;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Umbraco.Commerce.DemoStore
 {
@@ -43,6 +45,7 @@ namespace Umbraco.Commerce.DemoStore
             });
 
             umbracoBuilder.AddNotificationHandler<UmbracoApplicationStartingNotification, TransformExamineValues>();
+            umbracoBuilder.Services.ConfigureOptions<ConfigureIndexOptions>();
 
             return umbracoBuilder;
         }

--- a/src/Umbraco.Commerce.DemoStore/Events/TransformExamineValues.cs
+++ b/src/Umbraco.Commerce.DemoStore/Events/TransformExamineValues.cs
@@ -8,6 +8,9 @@ using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 using Umbraco.Commerce.DemoStore.Models;
 using System.Text;
+using Newtonsoft.Json;
+using Umbraco.Commerce.Core.Services;
+using System;
 
 namespace Umbraco.Commerce.DemoStore.Events
 {
@@ -15,19 +18,21 @@ namespace Umbraco.Commerce.DemoStore.Events
     {
         private readonly IExamineManager _examineManager;
         private readonly IUmbracoContextFactory _umbracoContextFactory;
+        private readonly ICurrencyService _currencyService;
 
         public TransformExamineValues(IExamineManager examineManager,
-            IUmbracoContextFactory umbracoContextFactory)
+            IUmbracoContextFactory umbracoContextFactory,
+            ICurrencyService currencyService)
         {
             _examineManager = examineManager;
             _umbracoContextFactory = umbracoContextFactory;
+            _currencyService = currencyService;
         }
-
 
         public void Handle(UmbracoApplicationStartingNotification notification)
         {
             // Listen for nodes being reindexed in the external index set
-            if (_examineManager.TryGetIndex("ExternalIndex", out var index))
+            if (_examineManager.TryGetIndex(Constants.UmbracoIndexes.ExternalIndexName, out var index))
             {
                 ((BaseIndexProvider)index).TransformingIndexValues += (object sender, IndexingItemEventArgs e) =>
                 {
@@ -70,6 +75,20 @@ namespace Umbraco.Commerce.DemoStore.Events
                             if (categoryAliases.Count > 0)
                             {
                                 values.Add("categoryAliases", new[] { string.Join(" ", categoryAliases) });
+                            }
+                        }
+
+                        if (e.ValueSet.Values.ContainsKey("price"))
+                        {
+                            var prices = JsonConvert.DeserializeObject<Dictionary<Guid, string>>(e.ValueSet.GetValue("price").ToString());
+
+                            foreach (var price in prices)
+                            {
+                                var currency = _currencyService.GetCurrency(price.Key);
+                                if (currency == null)
+                                    continue;
+
+                                values.Add($"price_{currency.Code}", new[] { price.Value });
                             }
                         }
                     }

--- a/src/Umbraco.Commerce.DemoStore/Web/Index/ConfigureIndexOptions.cs
+++ b/src/Umbraco.Commerce.DemoStore/Web/Index/ConfigureIndexOptions.cs
@@ -1,0 +1,35 @@
+﻿using Examine.Lucene;
+using Examine;
+using Microsoft.Extensions.Options;
+using Lucene.Net.Facet;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Commerce.DemoStore.Web.Index
+{
+    public sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
+    {
+        public void Configure(string name, LuceneDirectoryIndexOptions options)
+        {
+            switch (name)
+            {
+                case Constants.UmbracoIndexes.ExternalIndexName:
+
+                    var priceFields = new List<string>
+                    {
+                        "price_GBP"
+                    };
+
+                    foreach (var field in priceFields)
+                    {
+                        options.FieldDefinitions.TryAdd(new FieldDefinition(field, FieldDefinitionTypes.Double));
+                    }
+
+                    break;
+            }
+        }
+
+        public void Configure(LuceneDirectoryIndexOptions options)
+            => Configure(string.Empty, options);
+    }
+}


### PR DESCRIPTION
While playing with the upcoming facets in Examine v4, I found we can't use the existing indexed "price" field as facet field.
https://github.com/Shazwazza/Examine/issues/310

https://github.com/Shazwazza/Examine/blob/release/4.0/docs/v2/articles/configuration.md

With facets the index configuration would look something like this:

```
public void Configure(string name, LuceneDirectoryIndexOptions options)
{
    switch (name)
    {
        case Constants.UmbracoIndexes.ExternalIndexName:

            var priceFields = new List<string>
            {
                "price_GBP"
            };

            // Create a config
            var facetsConfig = new FacetsConfig();

            foreach (var field in priceFields)
            {
                options.FieldDefinitions.TryAdd(new FieldDefinition(field, FieldDefinitionTypes.FacetDouble));
                facetsConfig.SetIndexFieldName(field, $"facet_{field}");
            }

            options.FacetsConfig = facetsConfig;
            //options.UseTaxonomyIndex = true;

            break;
    }
}
```

```
var searcher = index.Searcher;
var query = searcher.CreateQuery().NativeQuery(q);

var results = query.OrderBy(new SortableField("name", SortType.String))
    .WithFacets(facets => facets
        .FacetDoubleRange("price_GBP", new DoubleRange[] {
            new DoubleRange("0-10", 0, true, 10, true),
            new DoubleRange("11-20", 11, true, 20, true),
            new DoubleRange("20-30", 21, true, 30, true)
        })) // Get facets of the price field
    .Execute(QueryOptions.SkipTake(pageSize * (page - 1), pageSize));

var facets = results.GetFacets(); 
```