### PR TITLE
Corrected database references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once you have all the files downloaded you can open the `Umbraco.Commerce.DemoSt
 *Optional* - Import `.\db\UmbracoCommerceDemoStore_v16.0.0.bacpac` using Data-tier application and update `ConnectionStrings` in `appsettings.json` to be similar like this:
 ```json
   "ConnectionStrings": {
-    "umbracoDbDSN": "Server=.;Database=UmbracoCommerceDemoStore_v13.1.0;User Id={your_db_username};Password={your_db_password};TrustServerCertificate=true;",
+    "umbracoDbDSN": "Server=.;Database=UmbracoCommerceDemoStore_v16.0.0;User Id={your_db_username};Password={your_db_password};TrustServerCertificate=true;",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
   }
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To get started with the Umbraco Commerce demo store you will need:
 * Visual Studio 2019.
 * .NET Core SDK 8.0.100 or newer.
 
-This demo store supports two database editions. By default it uses a `sqlite` database, but it also comes with a `.\dbs\DemoStore_v13_starter.bacpac` file which is exported from a SQL Server 2022.
+This demo store supports two database editions. By default it uses a `sqlite` database, but it also comes with a `.\db\UmbracoCommerceDemoStore_v16.0.0.bacpac` file which is exported from a SQL Server 2022.
 
 `sqlite` edition is fine if you just want to look around the store, but if you want to mess around, SQL Server edition is less likely be locked up when thing goes wrong.
 
@@ -33,7 +33,7 @@ git clone https://github.com/umbraco/Umbraco.Commerce.DemoStore.git
 
 Once you have all the files downloaded you can open the `Umbraco.Commerce.DemoStore.sln` solution file in the root of the repository in Visual Studio. Make sure the `Umbraco.Commerce.DemoStore.Web` project is the startup project by right clicking the project in the Solution Explorer and choosing `Set as StartUp Project`, and then press `Ctrl + F5` to launch the site.
 
-*Optional* - Import `.\db\UmbracoCommerceDemoStore_v13.1.0.bacpac` using Data-tier application and update `ConnectionStrings` in `appsettings.json` to be similar like this:
+*Optional* - Import `.\db\UmbracoCommerceDemoStore_v16.0.0.bacpac` using Data-tier application and update `ConnectionStrings` in `appsettings.json` to be similar like this:
 ```json
   "ConnectionStrings": {
     "umbracoDbDSN": "Server=.;Database=UmbracoCommerceDemoStore_v13.1.0;User Id={your_db_username};Password={your_db_password};TrustServerCertificate=true;",

--- a/src/Umbraco.Commerce.DemoStore.Web/appsettings.json
+++ b/src/Umbraco.Commerce.DemoStore.Web/appsettings.json
@@ -13,7 +13,7 @@
     "ConnectionStrings": {
         "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite",
-        "umbracoDbDSN1": "Server=localhost,3433;Database=UmbracoCommerceDemoStore_v15.0.0;User Id=mb;Password=password1234!;TrustServerCertificate=true;MultipleActiveResultSets=True;",
+        "umbracoDbDSN1": "Server=localhost,3433;Database=UmbracoCommerceDemoStore_v16.0.0;User Id=mb;Password=password1234!;TrustServerCertificate=true;MultipleActiveResultSets=True;",
         "umbracoDbDSN1_ProviderName": "Microsoft.Data.SqlClient"
     },
     "Umbraco": {


### PR DESCRIPTION
This pull request updates the demo store to use the new SQL Server database version `v16.0.0` instead of the previous `v13.x.x` versions. The changes affect documentation and configuration files to ensure consistency with the new database version.

**Documentation updates:**

* Updated references in `README.md` to use the new `UmbracoCommerceDemoStore_v16.0.0.bacpac` file for SQL Server setup instructions, replacing the old `v13` and `v13.1.0` references. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R39)

**Configuration updates:**

* Changed the SQL Server connection string in `appsettings.json` to reference the new `UmbracoCommerceDemoStore_v16.0.0` database instead of `v15.0.0`.